### PR TITLE
Fix grammar when user has failed to enter the correct passcode

### DIFF
--- a/Pod/Assets/en.lproj/DMPasscodeLocalisation.strings
+++ b/Pod/Assets/en.lproj/DMPasscodeLocalisation.strings
@@ -4,4 +4,5 @@
 "dmpasscode_not_match" = "Codes did not match, please try again.";
 "dmpasscode_okay" = "Okay";
 "dmpasscode_n_left" = "%i attempts left";
+"dmpasscode_1_left" = "1 attempt left";
 "dmpasscode_touchid_reason" = "Authenticate to access locked feature.";

--- a/Pod/Classes/DMPasscode.m
+++ b/Pod/Classes/DMPasscode.m
@@ -170,7 +170,11 @@ static NSBundle* bundle;
         if ([code isEqualToString:[[DMKeychain defaultKeychain] objectForKey:KEYCHAIN_NAME]]) {
             [self closeAndNotify:YES];
         } else {
-            [_passcodeViewController setErrorMessage:[NSString stringWithFormat:NSLocalizedString(@"dmpasscode_n_left", nil), 2 - _count]];
+            if (_count == 1) {
+                [_passcodeViewController setErrorMessage:NSLocalizedString(@"dmpasscode_1_left", nil)];
+            } else {
+                [_passcodeViewController setErrorMessage:[NSString stringWithFormat:NSLocalizedString(@"dmpasscode_n_left", nil), 2 - _count]];
+            }
             [_passcodeViewController reset];
             if (_count >= 2) { // max 3 attempts
                 [self closeAndNotify:NO];


### PR DESCRIPTION
Closes #26 